### PR TITLE
Add --help-config for agent-facing config discovery (v0.4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ npx create-volo-app my-app --config ./volo-config.json
 
 # Generate a config file interactively
 npx create-volo-app --init-config
+
+# Print schema + config-mode reference (for agents/CI)
+npx create-volo-app --help-config
 ```
 
 ## Upgrading from older CLI flags
@@ -139,7 +142,7 @@ These flags were removed; Commander no longer accepts them. If a script still pa
 
 ## Config file (`volo-config.json`)
 
-Use a config file for **non-interactive** or **CI** scaffolding. Pass it explicitly with `--config ./volo-config.json` (a file in the current directory is **not** loaded automatically).
+Use a config file for **non-interactive** or **CI** scaffolding. Pass it explicitly with `--config ./volo-config.json` (a file in the current directory is **not** loaded automatically). Run `npx create-volo-app --help-config` for the bundled JSON Schema, required fields, auth rules, and links to example configs — external tools can call this instead of duplicating CLI docs.
 
 **Do not commit your real config.** Treat `volo-config.json` like `.env`: it often holds database URLs and other secrets. Generated projects include `volo-config.json` in `.gitignore` by default. Safe, committed samples live under [`examples/`](examples/) — copy and edit those locally, or run `--init-config` to generate a new file.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-volo-app",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI tool to create AI-ready full-stack apps with an integrated React frontend, Hono backend, Auth, and Postgres database.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { checkPrerequisites } from './utils/prerequisites/checkPrereqs.js';
 import { logger } from './utils/logger.js';
 import { connectToService } from './commands/connect/index.js';
 import { showConnectionStatus } from './commands/connect/status.js';
-import { loadConfig, mergeConfigWithOptions, generateConfigInteractively, validateConfigForNonInteractive } from './utils/config.js';
+import { loadConfig, mergeConfigWithOptions, generateConfigInteractively, validateConfigForNonInteractive, printConfigHelp } from './utils/config.js';
 import { assertNoDeprecatedCliFlags } from './utils/deprecatedFlags.js';
 
 const require = createRequire(import.meta.url);
@@ -39,6 +39,7 @@ export async function main() {
     .option('--deploy [provider]', 'Production deployment setup (default: cloudflare)')
     .option('--config [path]', 'Use volo-config.json for non-interactive setup (defaults to ./volo-config.json in cwd)')
     .option('--init-config', 'Generate a volo-config.json via interactive wizard')
+    .option('--help-config', 'Print volo-config.json schema and config-mode reference, then exit')
     .addHelpText('after', `
 Examples:
   # Local development (default)
@@ -66,6 +67,9 @@ Examples:
   # Generate a config file
   npx create-volo-app --init-config
 
+  # Config schema and non-interactive reference (for agents/CI)
+  npx create-volo-app --help-config
+
   # Connect a service to existing project (run from project dir)
   npx create-volo-app --connect --auth
 
@@ -75,6 +79,12 @@ Examples:
     .action(async (projectName: string | undefined, options, command) => {
       try {
         logger.setVerbose(options.verbose);
+
+        // Handle --help-config: print schema reference and exit
+        if (options.helpConfig) {
+          printConfigHelp();
+          return;
+        }
 
         // Handle --init-config: generate config file and exit
         if (options.initConfig) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,6 +17,111 @@ export function getPublishedConfigSchemaUrl(version: string = packageVersion): s
   return `https://raw.githubusercontent.com/VoloBuilds/create-volo-app/v${version}/volo-config.schema.json`;
 }
 
+export function getPublishedExampleConfigUrl(
+  filename: string,
+  version: string = packageVersion
+): string {
+  return `https://raw.githubusercontent.com/VoloBuilds/create-volo-app/v${version}/examples/${filename}`;
+}
+
+function getBundledConfigSchemaPath(): string {
+  return path.resolve(__dirname, '..', '..', 'volo-config.schema.json');
+}
+
+function loadBundledConfigSchema(): Record<string, unknown> {
+  const schemaPath = getBundledConfigSchemaPath();
+  if (!fs.existsSync(schemaPath)) {
+    throw new Error(`Bundled config schema not found at ${schemaPath}`);
+  }
+  return JSON.parse(fs.readFileSync(schemaPath, 'utf-8')) as Record<string, unknown>;
+}
+
+export function printConfigHelp(): void {
+  const schemaUrl = getPublishedConfigSchemaUrl();
+  const examples = [
+    'volo-config.local.json',
+    'volo-config.production.json',
+    'volo-config.new-project.json',
+  ] as const;
+
+  const lines = [
+    `create-volo-app config reference (v${packageVersion})`,
+    '',
+    'CONFIG MODE',
+    '---------',
+    'npx create-volo-app --config ./volo-config.json',
+    'npx create-volo-app my-app --config ./volo-config.json',
+    '',
+    'Pass --config explicitly (bare flag defaults to ./volo-config.json in cwd).',
+    'Generate a starter file interactively: npx create-volo-app --init-config',
+    '',
+    'REQUIRED FIELDS (non-interactive)',
+    '---------------------------------',
+    '- projectName: target directory name (used when the CLI positional is omitted)',
+    '- database.action ("create" | "existing"): required when a database block is present',
+    '',
+    'SCHEMA-ENFORCED CONDITIONALS',
+    '-----------------------------',
+    '- auth.projectId: required when auth.action is "existing"',
+    '- database.projectName: required when database.action is "existing" and provider is neon or supabase',
+    '- database.connectionString: required when database.action is "existing" and provider is "other"',
+    '',
+    'SERVICE BLOCKS (CLI EQUIVALENTS)',
+    '--------------------------------',
+    '- auth: implies --auth (Firebase Authentication)',
+    '- database: implies --database <provider> (neon | supabase | other)',
+    '- deploy: implies --deploy cloudflare (provider defaults to "cloudflare")',
+    '',
+    'options.skipPrereqs — skip prerequisite checks',
+    'options.verbose — enable verbose logging',
+    'options.template — template URL or local path (#branch for branch); CLI --template wins if passed',
+    'options.overwrite — allow replacing an existing target directory (default: false)',
+    '',
+    'NON-INTERACTIVE AUTH RULES',
+    '--------------------------',
+    'Config mode never opens browser auth prompts. Pre-authenticate required CLIs before running,',
+    'or supply credentials in the config:',
+    '  - Firebase (auth): firebase login — or auth.projectId for an existing project',
+    '  - Neon (database.provider neon): neonctl auth — or database.connectionString',
+    '  - Supabase (database.provider supabase): supabase login — or database.connectionString',
+    '  - Cloudflare (deploy): wrangler login',
+    '',
+    'If authentication is still needed when --config runs, the CLI fails immediately.',
+    'Service setup does not retry in config mode. Manual Neon/Supabase fallbacks are disabled;',
+    'use connectionString or an authenticated CLI.',
+    '',
+    'EXAMPLE CONFIGS',
+    '---------------',
+    ...examples.flatMap((name) => [
+      `https://github.com/VoloBuilds/create-volo-app/blob/v${packageVersion}/examples/${name}`,
+      getPublishedExampleConfigUrl(name),
+    ]),
+    '',
+    'SCHEMA URL (for $schema in volo-config.json)',
+    '--------------------------------------------',
+    schemaUrl,
+    '',
+    'MINIMAL LOCAL EXAMPLE',
+    '---------------------',
+    JSON.stringify(
+      {
+        $schema: schemaUrl,
+        projectName: 'my-app',
+        options: { skipPrereqs: true, template: '/path/to/volo-app' },
+      },
+      null,
+      2
+    ),
+    '',
+    '--- volo-config.schema.json ---',
+    JSON.stringify(loadBundledConfigSchema(), null, 2),
+    '--- end volo-config.schema.json ---',
+    '',
+  ];
+
+  console.log(lines.join('\n'));
+}
+
 export interface VoloConfig {
   $schema?: string;
   projectName?: string;
@@ -55,8 +160,7 @@ let cachedValidate: ReturnType<Ajv['compile']> | null = null;
 function getSchemaValidator(): ReturnType<Ajv['compile']> | null {
   if (cachedValidate !== null) return cachedValidate;
 
-  // Resolve schema relative to the package root (two levels up from dist/utils/)
-  const schemaPath = path.resolve(__dirname, '..', '..', 'volo-config.schema.json');
+  const schemaPath = getBundledConfigSchemaPath();
   if (!fs.existsSync(schemaPath)) {
     logger.debug(`Schema file not found at ${schemaPath}, skipping schema validation`);
     return null;


### PR DESCRIPTION
## Summary
- Adds `--help-config` flag that prints bundled `volo-config.schema.json`, config-mode usage, required fields, auth rules, and versioned example config links
- Updates README to point agents/CI at `--help-config` instead of duplicating CLI docs
- Bumps version to `0.4.1`

## Test plan
- [x] `pnpm run build`
- [x] `node bin/cli.js --help-config` prints guide + schema with `v0.4.1` URLs
- [x] `node bin/cli.js --help` lists `--help-config`
- [ ] After merge: tag `v0.4.1`, `npm publish`, verify `npx create-volo-app@0.4.1 --help-config`


Made with [Cursor](https://cursor.com)